### PR TITLE
Fix layout overflow on Firefox

### DIFF
--- a/app.jsx
+++ b/app.jsx
@@ -188,20 +188,22 @@ var BellPlayer = React.createClass({
 		return (
 			<div>
 				<input type="date" min="2000-01-01" name="inputDate" id="inputDate" ref="inputDate" defaultValue={this.getToday()} onChange={this.dateChanged}/>
-				{this.state.currentDate && isNaN( this.state.currentDate.getTime())
-					? <div className="invalidDate">Not a valid date</div>
-					: this.state.currentSequences.map((sequence, index)=>{
-						return (
-							<BellRow 
-								key={'sequence-' + index}
-								index={index}
-								sequence={sequence} 
-								setCurrentSequence={this.setCurrentSequence} 
-								play={this.state.currentSequenceIndex === index} 
-								setDate={this.state.currentDate} />		
-						);
-					})
-				}
+				<div id="bellGrid">
+					{this.state.currentDate && isNaN( this.state.currentDate.getTime())
+						? <div className="invalidDate">Not a valid date</div>
+						: this.state.currentSequences.map((sequence, index)=>{
+							return (
+								<BellRow
+									key={'sequence-' + index}
+									index={index}
+									sequence={sequence}
+									setCurrentSequence={this.setCurrentSequence}
+									play={this.state.currentSequenceIndex === index}
+									setDate={this.state.currentDate} />
+							);
+						})
+					}
+				</div>
 			</div>
 		);
 	}

--- a/style.css
+++ b/style.css
@@ -4,17 +4,21 @@ body, html {
 }
 
 #inputDate {
-	margin: 0vh auto 3vh auto;
+	margin: 0vh auto;
 	font-size: 4vh;
 	display: block;
-	height: calc(9vh - 4px);
+	height: 8vh;
+	text-align: center;
+}
+
+#bellGrid {
+	position: absolute;
+	bottom: 0;
 }
 
 .bellWrapper {
-	width: 100vw;
 	position: relative;
 	cursor: pointer;
-	border-bottom: 1px solid #BBB;
 }
 
 .bellWrapper:hover .hoverbar {
@@ -29,15 +33,17 @@ body, html {
 
 .bellBlock {
 	width: 10vw;
-	height: calc(8vh - 1px);
+	height: 8vh;
+	box-sizing: border-box;
+	border-bottom: 1px solid #BBB;
 	background-color: red;
 	float: left;
 }
 
 .cover, .hoverbar {
 	width: 100%;
+	height: 100%;
 	background-color: rgba(255, 255, 255, 0.7);
-	height: 8vh;
 	position: absolute;
 }
 
@@ -47,8 +53,6 @@ body, html {
 
 .rowDate {
 	position: absolute;
-	width: calc(10vw - 5px);
-	height: 8vh;
 	line-height: 8vh;
 	padding-left: 5px;
 	font-family: 'Courier';


### PR DESCRIPTION
- firefox was rounding vh -> px conversions differently
- add bellGrid wrapper around grid to snap it to bottom of frame/window
- remove bottom margin from date entry as the margin will be defined by
  the empty space between it and the grid snapped to bottom
- Minor date styling, center text and shrink input slightly
- Move border from row to cells, allowing calc()-free implementation of
  cells/rows being 8vh tall
- row width is now defined by cumulative cell widths
- cover class can now just be width/height 100%
- rowDate width/height no longer needed
